### PR TITLE
Changed Example Workflow

### DIFF
--- a/scan/example.yaml
+++ b/scan/example.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: Upload report to GitHub Code Scanning.
         uses: github/codeql-action/upload-sarif@v1
         with:
-          sarif_file: "reliably.sarif"
+          sarif_file: reliably.sarif


### PR DESCRIPTION
As seen in the actual workflow used at: https://github.com/chaostoolkit/walkthrough/blob/main/.github/workflows/reliably.yaml it does not include the speech marks around `reliably.sarif` where they are included in this example

Signed-off-by: Charlie Moon <charlie@chaosiq.io>